### PR TITLE
Make sure the tile.png got valid data at startup

### DIFF
--- a/tilescript.js
+++ b/tilescript.js
@@ -238,5 +238,6 @@ loadImage(alltextures[~~rand].src);
 // Select first colour 
 
 palette.querySelector('li').click();
-});
+tosavestring(); 
+}); 
 })();


### PR DESCRIPTION
When opening the editor and immediatly trying to save the already existing tile, the tile.png is corrupt. The tosavefile() function to bind a valid PNG to the save button only gets created when at least one pixel has been changed.
By calling the function once at startup the save button returns a valid PNG right from the start. :D